### PR TITLE
Make Apap painkilling effect last twice long as before

### DIFF
--- a/addons/medical_treatment/ACE_Medical_Treatment.hpp
+++ b/addons/medical_treatment/ACE_Medical_Treatment.hpp
@@ -499,6 +499,7 @@ class ACE_ADDON(medical_treatment) {
         };
         class Apap: PainKillers {
             painReduce = 0.6;
+            timeInSystem = 1200;
             timeTillMaxEffect = 120;
         };
     };


### PR DESCRIPTION
**When merged this pull request will:**
- Increase Apap effect duration from 600 to 1200 s.

Some people say that Apap doesn't work at all and it can be caused by relatively long `timeTillMaxEffect` of 120 s and short `timeInSystem` of 600 s. This tweak should make Apap more efficient.